### PR TITLE
Redo vPath()

### DIFF
--- a/apis/tex.lua
+++ b/apis/tex.lua
@@ -135,9 +135,14 @@ local function vPath(width, height, depth)
     local shiftRight = false
     local shiftLeft = false
     return function()
+        --the turtle has been through every block
         if ht == height and wt == width and dt == depth then
             return nil
         end
+
+        --if either of these flags are true, the turtle is in the middle of shifting columns
+        --that means the turtle will turn, then move forward along the depth axis
+        --therefore, dt must be incremented by 1
         if shiftRight == true then
             dt = dt + 1
             shiftRight = false
@@ -147,13 +152,20 @@ local function vPath(width, height, depth)
             shiftLeft = false
             return dirs[2]
         end
+
+        --if the turtle has reached the end of a column
         if dt == depth then
+            --reset dt; the turtle is starting on a new column
             dt = 1
+            --if the turtle has reached the end of a layer
             if wt == width then
+                --reset the width travelled
                 wt = 1
+                --go to the next layer
                 ht = ht + 1
                 return dirs[4]
             end
+            --if the turtle is in the middle of a layer, shift columns
             --if width is even, flip turn direction at every even height
             --if wt % 2 == 1, turn right, else turn left
             local flip = (width%2 == 0 and ht % 2 == 0)

--- a/apis/tex.lua
+++ b/apis/tex.lua
@@ -139,9 +139,11 @@ local function vPath(width, height, depth)
             return nil
         end
         if shiftRight == true then
+            dt = dt + 1
             shiftRight = false
             return dirs[3]
         elseif shiftLeft == true then
+            dt = dt + 1
             shiftLeft = false
             return dirs[2]
         end

--- a/apis/tex.lua
+++ b/apis/tex.lua
@@ -132,14 +132,22 @@ local function vPath(width, height, depth)
     local dt = 1
     local wt = 1
     local ht = 1
+    local shiftRight = false
+    local shiftLeft = false
     return function()
         if ht == height and wt == width and dt == depth then
             return nil
         end
+        if shiftRight == true then
+            shiftRight = false
+            return dirs[3]
+        elseif shiftLeft == true then
+            shiftLeft = false
+            return dirs[2]
+        end
         if dt == depth then
-            dt = 1
+            dt = 0
             if wt == width then
-                wt = 1
                 ht = ht + 1
                 return dirs[4]
             end
@@ -147,9 +155,11 @@ local function vPath(width, height, depth)
             --if wt % 2 == 1, turn right, else turn left
             local flip = (width%2 == 0 and ht % 2 == 0)
             if (wt%2 == 0 and flip) or (wt%2 == 1 and not flip) then
+                shiftRight = true
                 wt = wt + 1
                 return dirs[3]
             else
+                shiftLeft = true
                 wt = wt + 1
                 return dirs[2]
             end

--- a/apis/tex.lua
+++ b/apis/tex.lua
@@ -146,8 +146,9 @@ local function vPath(width, height, depth)
             return dirs[2]
         end
         if dt == depth then
-            dt = 0
+            dt = 1
             if wt == width then
+                wt = 1
                 ht = ht + 1
                 return dirs[4]
             end

--- a/apis/tprint.lua
+++ b/apis/tprint.lua
@@ -53,12 +53,10 @@ local function scan(name, width, height, depth)
             tex.left()
             handleBlock(result)
             tex.forward(1,true)
-            tex.left()
         elseif instruction == "right" then
             tex.right()
             handleBlock(result)
             tex.forward(1,true)
-            tex.right()
         elseif instruction == "up" then
             tex.turnAround()
             handleBlock(result,true)
@@ -79,11 +77,9 @@ local function print(tcodeObj)
         if instruction == "left" then
             tex.left()
             tex.forward()
-            tex.left()
         elseif instruction == "right" then
             tex.right()
             tex.forward()
-            tex.right()
         elseif instruction == "up" then
             tex.turnAround()
             tex.up()

--- a/programs/make-room.lua
+++ b/programs/make-room.lua
@@ -35,11 +35,9 @@ for instruction in tex.vPath(width, height, depth) do
     elseif instruction == "left" then
         tex.left()
         tex.forward(1, true)
-        tex.left()
     elseif instruction == "right" then
         tex.right()
         tex.forward(1, true)
-        tex.right()
     elseif instruction == "forward" then
         tex.forward(1, true)
     end


### PR DESCRIPTION
`tex.vPath()`'s  return values' meanings have changed:

- `"right"` now means "turn right, move forward" rather than "turn right, move forward, turn right" 
- `"left"` now means "turn left, move forward" rather than "turn left, move forward, turn left"

This allows programs and APIs that use `tex.vPath()`'s return format to be interfaced with easier, such as the tprint API. The goal of this is to allow me to make programs that write more optimized tcode, because as of right now, `tprint.scan()`'s output requires turtles to move through every block in a volume to print the tcode's structure.